### PR TITLE
Implement Survivor's registration endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+* POST `/survivors` endpoint for Survivor registration.
 * Inventory model that represents a survivor inventory.
 * Survivor model that represents a infected or non-infected person.
 * Stack model that represents a stack of items.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::API
+  rescue_from ArgumentError, with: :render_error
+
+  protected
+
+  def render_error(e)
+    render json: {error: e.message}, status: :unprocessable_entity
+  end
 end

--- a/app/controllers/survivors_controller.rb
+++ b/app/controllers/survivors_controller.rb
@@ -1,0 +1,21 @@
+class SurvivorsController < ApplicationController
+  def create
+    survivor = survivor_service.register
+
+    if survivor.save
+      render json: survivor.to_json, status: :created
+    else
+      render json: {error: survivor.errors}, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def survivor_service
+    SurvivorService.new(survivor_params)
+  end
+
+  def survivor_params
+    params.permit :name, :age, :gender, :last_location, :inventory
+  end
+end

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -1,4 +1,6 @@
 class Inventory < ApplicationRecord
-  has_many :stacks
+  has_many :stacks, inverse_of: :inventory
   belongs_to :survivor
+
+  accepts_nested_attributes_for :stacks
 end

--- a/app/models/survivor.rb
+++ b/app/models/survivor.rb
@@ -6,5 +6,7 @@ class Survivor < ApplicationRecord
 
   enum gender: [:male, :female]
 
-  has_one :inventory
+  has_one :inventory, inverse_of: :survivor
+
+  accepts_nested_attributes_for :inventory
 end

--- a/app/services/survivor_service.rb
+++ b/app/services/survivor_service.rb
@@ -1,0 +1,47 @@
+class SurvivorService
+  def initialize(params)
+    @name = params[:name]
+    @age = params[:age]
+    @gender = params[:gender]
+    @latitude, @longitude = coordinates_from params[:last_location]
+    @inventory = inventory_from params[:inventory]
+  end
+
+  def register
+    params = {
+        name: @name,
+        age: @age,
+        gender: @gender,
+        latitude: @latitude,
+        longitude: @longitude
+    }
+    unless @inventory == nil
+      params.merge!(inventory_attributes: @inventory)
+    end
+    Survivor.new(params)
+  end
+
+  private
+
+  def coordinates_from(value)
+    if value == nil
+      return [nil, nil]
+    end
+    value.split(',').collect {|l| l.to_f}
+  end
+
+  def inventory_from(value)
+    return if value == nil
+    {stacks_attributes: stacks_from(value)}
+  end
+
+  def stack_from(from)
+    item_name, quantity = from.split(':')
+    item = Item.where(name: item_name).first
+    {quantity: quantity.to_i, item: item}
+  end
+
+  def stacks_from(from)
+    from.split(',').collect {|v| stack_from v}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
+  post 'survivors/', to: 'survivors#create'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,8 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Item.create name: 'Water', value: 4
+Item.create name: 'Food', value: 3
+Item.create name: 'Medication', value: 2
+Item.create name: 'Ammunition', value: 1

--- a/spec/controllers/survivors_controller_spec.rb
+++ b/spec/controllers/survivors_controller_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe SurvivorsController, type: :controller do
+  let(:valid_data) {
+    {
+        name: 'Test Survivor',
+        age: 20,
+        gender: 'male',
+        inventory: 'Water:5,Food:11'
+    }
+  }
+
+  let(:invalid_data) {
+    {
+        name: nil,
+        age: nil,
+        gender: 'alien',
+        inventory: nil
+    }
+  }
+
+  describe 'POST #create' do
+    context 'with valid data' do
+      it 'returns http 201 created' do
+        post :create, params: valid_data
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns the registered Survivor' do
+        post :create, params: valid_data
+        expect(json['name']).to eq (valid_data[:name])
+      end
+
+      it 'registers a new survivor' do
+        expect {
+          post :create, params: valid_data
+        }.to change { Survivor.count }
+      end
+
+      it 'registers a new inventory' do
+        expect {
+          post :create, params: valid_data
+        }.to change { Inventory.count }
+      end
+
+      it 'registers new stacks' do
+        expect {
+          post :create, params: valid_data
+        }.to change { Stack.count }
+      end
+    end
+    context 'with invalid data' do
+      it 'returns http 422 unprocessable entity' do
+        post :create, params: invalid_data
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns an error message' do
+        post :create, params: invalid_data
+        expect(json['error']).to be_a String
+      end
+
+      it 'does not register a new survivor' do
+        expect {
+          post :create, params: invalid_data
+        }.to_not change { Survivor.count }
+      end
+
+      it 'does not register a new inventory' do
+        expect {
+          post :create, params: invalid_data
+        }.to_not change { Inventory.count }
+      end
+
+      it 'does not register new stacks' do
+        expect {
+          post :create, params: invalid_data
+        }.to_not change { Stack.count }
+      end
+    end
+  end
+end

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,0 +1,11 @@
+module Requests
+  module JsonHelper
+    def json
+      JSON.parse(response.body)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Requests::JsonHelper
+end


### PR DESCRIPTION
Adds survivors#create (POST `/survivor`) that allows survivor's registration.